### PR TITLE
Pulp v.2 package version support

### DIFF
--- a/manifests/admin.pp
+++ b/manifests/admin.pp
@@ -1,12 +1,13 @@
 # class pulp::admin
 class pulp::admin (
 $pulp_server_host = 'localhost.localdomain',
-$pulp_server_port = '443'
+$pulp_server_port = '443',
+$package_version   = 'installed'
 ) {
 
   $packagelist = ['pulp-admin-client', 'pulp-puppet-admin-extensions','pulp-rpm-admin-extensions']
   package { $packagelist:
-    ensure  => 'installed',
+    ensure  => $package_version,
   }
   file { '/etc/pulp/admin/admin.conf':
     ensure  => 'file',

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -1,11 +1,12 @@
 # Class pulp::client
 class pulp::client (
   $pulp_server_host = undef,
-  $pulp_server_port = '443'
+  $pulp_server_port = '443',
+  $package_version   = 'installed'
 ) {
   $packagelist = ['pulp-agent', 'pulp-consumer-client','pulp-puppet-handlers', 'pulp-rpm-consumer-extensions', 'pulp-rpm-handlers']
   package { $packagelist:
-    ensure  => 'installed',
+    ensure  => $package_version,
   }
   file { '/etc/pulp/consumer/consumer.conf':
     ensure  => 'file',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -164,6 +164,7 @@ class pulp (
       class { 'pulp::client':
         pulp_server_host => $pulp_server_host,
         pulp_server_port => $pulp_server_port,
+        package_version  => $package_version,
         require          => Class['pulp::repo']
       }
     }
@@ -171,6 +172,7 @@ class pulp (
       class { 'pulp::admin':
         pulp_server_host => $pulp_server_host,
         pulp_server_port => $pulp_server_port,
+        package_version  => $package_version,
         require          => Class['pulp::repo']
       }
     }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,6 +56,9 @@
 # [*migrate_wait_secs*]
 #   Number of seconds to wait between pulp-manage-db attempts.
 #
+# [*package_version*]
+#   Set installation version e.g. 2.1.0, installed or latest.
+#   Current supported under pulp v2 only.
 #
 # == Actions
 #
@@ -114,7 +117,8 @@ class pulp (
   $qpid_server       = 'localhost.localdomain',
   $qpid_port         = '5672',
   $migrate_attempts  = '3',
-  $migrate_wait_secs = '5'
+  $migrate_wait_secs = '5',
+  $package_version   = 'installed'
 ) {
 
   #Validation
@@ -123,6 +127,7 @@ class pulp (
   validate_bool($pulp_client)
   validate_bool($pulp_admin)
   validate_bool($repo_enabled)
+  validate_re($package_version, ['^installed$', '^latest$', '^2\.'])
   validate_re($mail_enabled, [ '^true$', '^false$' ])
 
   anchor{ 'pulp::begin': }
@@ -151,6 +156,7 @@ class pulp (
         pulp_server_host  => $pulp_server_host,
         migrate_attempts  => $migrate_attempts,
         migrate_wait_secs => $migrate_wait_secs,
+        package_version   => $package_version,
         require           => Class['pulp::repo']
       }
     }

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -38,6 +38,9 @@
 # [*migrate_wait_secs*]
 #   Seconds to wait between retry attempts to execute pulp-manage-db.
 #
+# [*package_version*]
+#   Set installation version e.g. 2.1.0, installed or latest.
+#
 # == Actions
 #
 # == Requires
@@ -45,8 +48,6 @@
 # == Sample Usage
 #
 # == Todo
-#
-#  * Add documentation.
 #
 class pulp::server (
   $mail_enabled      = 'false',
@@ -59,12 +60,13 @@ class pulp::server (
   $qpid_port         = '5672',
   $pulp_server_host  = 'localhost.localdomain',
   $migrate_attempts  = '3',
-  $migrate_wait_secs = '5'
+  $migrate_wait_secs = '5',
+  $package_version   = 'installed'
 ) {
   $packagelist = ['pulp-puppet-plugins', 'pulp-rpm-plugins', 'pulp-selinux', 'pulp-server']
 
   package { $packagelist:
-    ensure => installed,
+    ensure => $package_version,
   }
   file { '/etc/pulp/server.conf':
     owner   => 'root',

--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -165,4 +165,41 @@ describe 'pulp', :type => :class do
     it { should contain_file('/etc/pulp/admin/admin.conf').with_content(/port\s=\s443/)}
   end
 
+  context 'Install specific package version of pulp server version 2' do
+    let :fact do {
+        :osfamily => 'RedHat'
+    }
+    end
+
+    let :params do {
+        :pulp_version => '2',
+        :pulp_server  => true,
+        :package_version => '2.1.0'
+    }
+    end
+
+    it { should contain_package('pulp-server').with( :ensure => '2.1.0') }
+    it { should contain_package('pulp-selinux').with( :ensure => '2.1.0') }
+    it { should contain_package('pulp-rpm-plugins').with( :ensure => '2.1.0') }
+    it { should contain_package('pulp-puppet-plugins').with( :ensure => '2.1.0') }
+  end
+
+  context 'Install default package version of pulp server version 2' do
+    let :fact do {
+        :osfamily => 'RedHat'
+    }
+    end
+
+    let :params do {
+        :pulp_version => '2',
+        :pulp_server  => true
+    }
+    end
+
+    it { should contain_package('pulp-server').with( :ensure => 'installed') }
+    it { should contain_package('pulp-selinux').with( :ensure => 'installed') }
+    it { should contain_package('pulp-rpm-plugins').with( :ensure => 'installed') }
+    it { should contain_package('pulp-puppet-plugins').with( :ensure => 'installed') }
+  end
+
 end

--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -192,7 +192,28 @@ describe 'pulp', :type => :class do
 
     let :params do {
         :pulp_version => '2',
-        :pulp_client  => true
+        :pulp_client  => true,
+        :package_version => '2.1.0'
+    }
+    end
+
+    it { should contain_package('pulp-agent').with( :ensure => '2.1.0') }
+    it { should contain_package('pulp-consumer-client').with( :ensure => '2.1.0') }
+    it { should contain_package('pulp-puppet-handlers').with( :ensure => '2.1.0') }
+    it { should contain_package('pulp-rpm-consumer-extensions').with( :ensure => '2.1.0') }
+    it { should contain_package('pulp-rpm-handlers').with( :ensure => '2.1.0') }
+  end
+
+  context 'Install specific package version of pulp v.2 administration client' do
+    let :facts do {
+        :osfamily => 'RedHat'
+    }
+    end
+
+    let :params do {
+        :pulp_version => '2',
+        :pulp_admin  => true,
+        :package_version => '2.1.0'
     }
     end
 

--- a/spec/classes/pulp_spec.rb
+++ b/spec/classes/pulp_spec.rb
@@ -184,7 +184,7 @@ describe 'pulp', :type => :class do
     it { should contain_package('pulp-puppet-plugins').with( :ensure => '2.1.0') }
   end
 
-  context 'Install default package version of pulp server version 2' do
+  context 'Install specific package version of pulp client version 2' do
     let :fact do {
         :osfamily => 'RedHat'
     }
@@ -192,14 +192,13 @@ describe 'pulp', :type => :class do
 
     let :params do {
         :pulp_version => '2',
-        :pulp_server  => true
+        :pulp_client  => true
     }
     end
 
-    it { should contain_package('pulp-server').with( :ensure => 'installed') }
-    it { should contain_package('pulp-selinux').with( :ensure => 'installed') }
-    it { should contain_package('pulp-rpm-plugins').with( :ensure => 'installed') }
-    it { should contain_package('pulp-puppet-plugins').with( :ensure => 'installed') }
+    it { should contain_package('pulp-admin-client').with( :ensure => '2.1.0') }
+    it { should contain_package('pulp-puppet-admin-extensions').with( :ensure => '2.1.0') }
+    it { should contain_package('pulp-rpm-admin-extensions').with( :ensure => '2.1.0') }
   end
 
 end


### PR DESCRIPTION
Added Pulp v.2 package version support to installation version e.g. 2.1.0, installed or latest.
